### PR TITLE
Add initial municipal AI playbook structure

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -1,0 +1,15 @@
+---
+name: "Suggestion"
+about: Propose an idea or request content
+title: "[Suggestion]"
+labels: enhancement
+---
+
+## Summary
+Describe the improvement or new content.
+
+## Category / File
+Which category or file does this relate to?
+
+## Additional context
+Anything else we should know?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+- What problem does this pull request solve?
+
+## Testing
+- [ ] Built site locally
+- [ ] Viewed page(s) in browser
+
+## Notes for reviewers
+Anything special to call out?
+
+Closes #

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# ai-playbook
-An exploratory AI playbook framework.
+# Municipal AI Playbook
+
+This repository houses guidance and playbooks that help city staff explore AI in day‑to‑day work.
+The content is organized by community categories so finance, HR, leadership, communications and
+other teams can quickly find material written for them.
+
+## How to use
+1. Browse the `docs/` folder or visit the GitHub Pages site to navigate by category.
+2. Start with **Getting Started** if you’re new to AI in the workplace.
+3. Each playbook follows a consistent format: why it matters, outcomes, checklist, artifacts,
+   and anti‑patterns.
+
+## Contribution notes
+- Issues and suggestions: open an issue using the suggestion template.
+- Pull requests: follow the PR template.
+- Content should reflect OpenAI values—humanity first, humility, creativity over control,
+  and rapid updates—and align with the AI Adoption Manager role by codifying best
+  practices and FAQs for municipal audiences.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,4 @@
+title: Municipal AI Playbook
+description: Practical AI adoption guides for city staff
+theme: minima
+markdown: kramdown

--- a/docs/Champions/index.md
+++ b/docs/Champions/index.md
@@ -1,0 +1,6 @@
+# Champions
+
+Support peer-led learning and momentum.
+
+- [Identifying and Empowering AI Champions](playbook-identifying-and-empowering-ai-champions.md)
+- [Running AI Learning Circles](playbook-running-ai-learning-circles.md)

--- a/docs/Champions/playbook-identifying-and-empowering-ai-champions.md
+++ b/docs/Champions/playbook-identifying-and-empowering-ai-champions.md
@@ -1,0 +1,21 @@
+# Playbook: Identifying and Empowering AI Champions
+
+## Why this matters
+Champions model safe experimentation and mentor peers.
+
+## Outcomes to target
+- Active champions in every department.
+- Shared repository of successful use cases.
+
+## Checklist
+- Ask managers to nominate staff curious about AI.
+- Provide champions early access to new features.
+- Recognize contributions at all-hands meetings.
+
+## Artifacts
+- Champion nomination form
+- Use case library
+
+## Anti-patterns
+- Selecting only tech staff; diversity is key.
+- Expecting champions to work without support.

--- a/docs/Champions/playbook-running-ai-learning-circles.md
+++ b/docs/Champions/playbook-running-ai-learning-circles.md
@@ -1,0 +1,21 @@
+# Playbook: Running AI Learning Circles
+
+## Why this matters
+Small group sessions build confidence and accelerate adoption.
+
+## Outcomes to target
+- Regular attendance and cross-department collaboration.
+- Documented lessons from each session.
+
+## Checklist
+- Choose a monthly topic (e.g., automating permit summaries).
+- Limit groups to 8–10 participants.
+- Capture notes and share recordings.
+
+## Artifacts
+- Session agenda
+- Learning summary
+
+## Anti-patterns
+- Turning sessions into slide lectures.
+- Skipping facilitation for quiet voices.

--- a/docs/Communications/index.md
+++ b/docs/Communications/index.md
@@ -1,0 +1,6 @@
+# Communications
+
+Help staff and communities understand AI changes.
+
+- [Crafting Clear AI Communications for Staff](playbook-crafting-clear-ai-communications-for-staff.md)
+- [Community Messaging & Transparency](playbook-community-messaging-and-transparency.md)

--- a/docs/Communications/playbook-community-messaging-and-transparency.md
+++ b/docs/Communications/playbook-community-messaging-and-transparency.md
@@ -1,0 +1,21 @@
+# Playbook: Community Messaging & Transparency
+
+## Why this matters
+Residents expect honesty about new technologies affecting services.
+
+## Outcomes to target
+- Public notice explaining AI use in permitting or budgeting.
+- Easy way for residents to ask questions.
+
+## Checklist
+- Publish a webpage with overview, contact info, and update log.
+- Use real examples (e.g., “AI helps summarize open comments on park designs”).
+- Coordinate with communications and legal teams.
+
+## Artifacts
+- Web copy
+- Media toolkit
+
+## Anti-patterns
+- Releasing technical jargon.
+- Hiding limitations or pilot status.

--- a/docs/Communications/playbook-crafting-clear-ai-communications-for-staff.md
+++ b/docs/Communications/playbook-crafting-clear-ai-communications-for-staff.md
@@ -1,0 +1,21 @@
+# Playbook: Crafting Clear AI Communications for Staff
+
+## Why this matters
+Transparent internal communication reduces confusion and rumors.
+
+## Outcomes to target
+- Staff know when and how AI is used.
+- Feedback channels are clear.
+
+## Checklist
+- Explain purpose in plain language (“to speed up grant reports”).
+- Share data handling safeguards.
+- Offer Q&A sessions during rollout.
+
+## Artifacts
+- FAQ document
+- Sample newsletter blurb
+
+## Anti-patterns
+- Overhyping capabilities.
+- Sending one email and assuming message landed.

--- a/docs/Data-Analytics/index.md
+++ b/docs/Data-Analytics/index.md
@@ -1,0 +1,6 @@
+# Data & Analytics
+
+Guides for analysts using AI with city data.
+
+- [Using AI to Accelerate Reporting](playbook-using-ai-to-accelerate-reporting.md)
+- [Safe Use of Data in AI Workflows](playbook-safe-use-of-data-in-ai-workflows.md)

--- a/docs/Data-Analytics/playbook-safe-use-of-data-in-ai-workflows.md
+++ b/docs/Data-Analytics/playbook-safe-use-of-data-in-ai-workflows.md
@@ -1,0 +1,21 @@
+# Playbook: Safe Use of Data in AI Workflows
+
+## Why this matters
+Protecting resident data maintains trust and complies with law.
+
+## Outcomes to target
+- Clear classification of data before uploading.
+- Audit trail of datasets used.
+
+## Checklist
+- Tag datasets as public, internal, or restricted.
+- Use anonymized samples when possible.
+- Record data sources in project notes.
+
+## Artifacts
+- Data inventory sheet
+- Access request log
+
+## Anti-patterns
+- Uploading unredacted personal information.
+- Mixing restricted data with public projects.

--- a/docs/Data-Analytics/playbook-using-ai-to-accelerate-reporting.md
+++ b/docs/Data-Analytics/playbook-using-ai-to-accelerate-reporting.md
@@ -1,0 +1,21 @@
+# Playbook: Using AI to Accelerate Reporting
+
+## Why this matters
+AI can draft reports so analysts focus on insights rather than formatting.
+
+## Outcomes to target
+- Faster production of quarterly budget or crime reports.
+- Consistent narrative style.
+
+## Checklist
+- Feed AI structured data exports.
+- Provide templates with required headings.
+- Validate summaries against source numbers.
+
+## Artifacts
+- Report template
+- Validation checklist
+
+## Anti-patterns
+- Allowing AI to infer data not provided.
+- Skipping human review.

--- a/docs/Finance-Budgeting/index.md
+++ b/docs/Finance-Budgeting/index.md
@@ -1,0 +1,6 @@
+# Finance & Budgeting
+
+AI tools for financial planning and procurement.
+
+- [Budget Forecasting with AI](playbook-budget-forecasting-with-ai.md)
+- [Streamlining Procurement with AI](playbook-streamlining-procurement-with-ai.md)

--- a/docs/Finance-Budgeting/playbook-budget-forecasting-with-ai.md
+++ b/docs/Finance-Budgeting/playbook-budget-forecasting-with-ai.md
@@ -1,0 +1,21 @@
+# Playbook: Budget Forecasting with AI
+
+## Why this matters
+AI helps finance teams model revenue and expense scenarios quickly.
+
+## Outcomes to target
+- Faster projections of property tax revenue.
+- Clear explanations for council and the public.
+
+## Checklist
+- Gather historic revenue and expense data.
+- Generate multiple forecast scenarios.
+- Document assumptions and review with budget officers.
+
+## Artifacts
+- Forecast spreadsheet
+- Assumption memo
+
+## Anti-patterns
+- Treating AI output as final without analyst validation.
+- Ignoring outliers like one-time grants.

--- a/docs/Finance-Budgeting/playbook-streamlining-procurement-with-ai.md
+++ b/docs/Finance-Budgeting/playbook-streamlining-procurement-with-ai.md
@@ -1,0 +1,21 @@
+# Playbook: Streamlining Procurement with AI
+
+## Why this matters
+AI can sift through vendor proposals and flag key details.
+
+## Outcomes to target
+- Shorter review cycles for RFPs.
+- Better comparisons of vendor deliverables.
+
+## Checklist
+- Upload proposal PDFs to an approved workspace.
+- Ask AI to extract timelines, costs, and compliance notes.
+- Record findings in the procurement tracker.
+
+## Artifacts
+- Proposal summary sheet
+- Decision log
+
+## Anti-patterns
+- Letting AI rate vendors without criteria.
+- Discarding procurement rules.

--- a/docs/Getting-Started/guidance-projects-vs-custom-gpts.md
+++ b/docs/Getting-Started/guidance-projects-vs-custom-gpts.md
@@ -1,0 +1,10 @@
+# Guidance: Projects vs. Custom GPTs
+
+City staff often ask whether to start with a **Project** or a **Custom GPT**.
+
+- **Projects** are personal workspaces. Use them for experimenting on tasks like drafting permit
+  letters or summarizing council agendas. Great for individual productivity.
+- **Custom GPTs** are shareable assistants. Use them when multiple staff need the same workflow,
+  such as a GPT for common zoning questions or HR policy lookups.
+
+**Tip:** Start in a Project to prove value, then convert the workflow into a Custom GPT for team use.

--- a/docs/Getting-Started/index.md
+++ b/docs/Getting-Started/index.md
@@ -1,0 +1,7 @@
+# Getting Started
+
+Introductory guides for staff exploring AI tools in city work.
+
+- [Projects vs. Custom GPTs](guidance-projects-vs-custom-gpts.md)
+- [Working with a Project (Personal Workspace)](playbook-working-with-a-project.md)
+- [Building a Custom GPT (Team Sharing)](playbook-building-a-custom-gpt.md)

--- a/docs/Getting-Started/playbook-building-a-custom-gpt.md
+++ b/docs/Getting-Started/playbook-building-a-custom-gpt.md
@@ -1,0 +1,22 @@
+# Playbook: Building a Custom GPT (Team Sharing)
+
+## Why this matters
+Custom GPTs let departments share reliable workflows, reducing duplicate effort.
+
+## Outcomes to target
+- Standard responses to common inquiries.
+- Consistent processes for permit reviews or budget analyses.
+
+## Checklist
+- Identify repetitive requests from colleagues.
+- Build the workflow in a Project first.
+- Create a Custom GPT with clear instructions and test with a small team.
+- Document usage guidelines in the GPT description.
+
+## Artifacts
+- Source prompts
+- Usage doc for staff
+
+## Anti-patterns
+- Launching without stakeholder review.
+- Overloading the GPT with unrelated tasks.

--- a/docs/Getting-Started/playbook-working-with-a-project.md
+++ b/docs/Getting-Started/playbook-working-with-a-project.md
@@ -1,0 +1,21 @@
+# Playbook: Working with a Project (Personal Workspace)
+
+## Why this matters
+Projects let staff explore AI privately before sharing workflows.
+
+## Outcomes to target
+- Draft routine documents faster (e.g., permit conditions).
+- Capture learning safely before wider deployment.
+
+## Checklist
+- Define a small task to automate.
+- Set privacy settings so only you can access the project.
+- Log useful prompts and results for later reuse.
+
+## Artifacts
+- Prompt log
+- Example outputs
+
+## Anti-patterns
+- Uploading sensitive resident data without approval.
+- Treating a project as a finished solution for others.

--- a/docs/HR/index.md
+++ b/docs/HR/index.md
@@ -1,0 +1,6 @@
+# Human Resources
+
+Improve workforce processes with AI.
+
+- [Training & Onboarding with AI](playbook-training-and-onboarding-with-ai.md)
+- [Staff Surveys & Feedback Analysis](playbook-staff-surveys-and-feedback-analysis.md)

--- a/docs/HR/playbook-staff-surveys-and-feedback-analysis.md
+++ b/docs/HR/playbook-staff-surveys-and-feedback-analysis.md
@@ -1,0 +1,21 @@
+# Playbook: Staff Surveys & Feedback Analysis
+
+## Why this matters
+AI summarizes open-ended responses, giving HR faster insight.
+
+## Outcomes to target
+- Themes identified within days of survey close.
+- Actions tied to staff concerns.
+
+## Checklist
+- Export survey comments to CSV.
+- Prompt AI to cluster sentiments and list top themes.
+- Share summary with leadership and staff.
+
+## Artifacts
+- Sentiment summary
+- Action plan
+
+## Anti-patterns
+- Publishing raw comments without context.
+- Ignoring minority viewpoints.

--- a/docs/HR/playbook-training-and-onboarding-with-ai.md
+++ b/docs/HR/playbook-training-and-onboarding-with-ai.md
@@ -1,0 +1,21 @@
+# Playbook: Training & Onboarding with AI
+
+## Why this matters
+AI personalizes learning and shortens time-to-productivity for new hires.
+
+## Outcomes to target
+- Tailored onboarding schedules.
+- Quick answers to policy questions.
+
+## Checklist
+- Create a Custom GPT with links to policies and forms.
+- Provide new hires a step-by-step onboarding guide.
+- Collect feedback after week one.
+
+## Artifacts
+- Onboarding GPT guide
+- Feedback form
+
+## Anti-patterns
+- Overloading new staff with AI tools on day one.
+- Leaving outdated policies in the GPT.

--- a/docs/Leadership/index.md
+++ b/docs/Leadership/index.md
@@ -1,0 +1,6 @@
+# Leadership
+
+Strategies for executives and department heads guiding AI adoption.
+
+- [Leading AI Adoption in a Municipality](playbook-leading-ai-adoption-in-a-municipality.md)
+- [Building an AI Champions Network](playbook-building-an-ai-champions-network.md)

--- a/docs/Leadership/playbook-building-an-ai-champions-network.md
+++ b/docs/Leadership/playbook-building-an-ai-champions-network.md
@@ -1,0 +1,21 @@
+# Playbook: Building an AI Champions Network
+
+## Why this matters
+Champions spread know-how across departments, scaling adoption sustainably.
+
+## Outcomes to target
+- Named champion in every major division.
+- Regular sharing of wins and lessons learned.
+
+## Checklist
+- Invite volunteers from finance, HR, planning, etc.
+- Provide monthly learning sessions.
+- Publish a shared library of prompts and case studies.
+
+## Artifacts
+- Champion roster
+- Meeting notes
+
+## Anti-patterns
+- Champions without time allocated.
+- Hoarding knowledge instead of sharing.

--- a/docs/Leadership/playbook-leading-ai-adoption-in-a-municipality.md
+++ b/docs/Leadership/playbook-leading-ai-adoption-in-a-municipality.md
@@ -1,0 +1,21 @@
+# Playbook: Leading AI Adoption in a Municipality
+
+## Why this matters
+Clear leadership sets direction and earns trust for responsible AI use.
+
+## Outcomes to target
+- Shared vision tied to city priorities (e.g., faster permit turnaround).
+- Policies balancing innovation and resident protection.
+
+## Checklist
+- Draft an AI statement referencing OpenAI values: humanity first, humility, creativity over control.
+- Form a cross-department steering group.
+- Pilot two high-impact use cases and publish results.
+
+## Artifacts
+- AI adoption roadmap
+- Steering group charter
+
+## Anti-patterns
+- Mandating tools without staff input.
+- Ignoring legal or ethical considerations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# AI Playbook Academy
+
+Welcome! This site helps municipal staff adopt AI responsibly and effectively.  
+Choose a category to get started:
+
+- [Getting Started](Getting-Started/)
+- [Leadership](Leadership/)
+- [Communications](Communications/)
+- [Data & Analytics](Data-Analytics/)
+- [Finance & Budgeting](Finance-Budgeting/)
+- [HR](HR/)
+- [Champions](Champions/)


### PR DESCRIPTION
## Summary
- scaffold GitHub Pages docs with community categories and playbooks
- add contribution templates and Jekyll configuration

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b3178ffce4832083b754ceb853e2e2